### PR TITLE
day_of_quarter incorrect?

### DIFF
--- a/models/metrics/metrics/intermediate/metrics__calculated.sql
+++ b/models/metrics/metrics/intermediate/metrics__calculated.sql
@@ -29,7 +29,7 @@ windowed as (
         *,
         
         row_number() over (
-            partition by date_quarter
+            partition by metric_name, date_quarter
             order by date_day
         ) as day_of_quarter,
         


### PR DESCRIPTION
From what I understand, `day_of_quarter` should reflect the position of `date_day` for each metric within the quarter.